### PR TITLE
Fix json gem version to avoid conflict version

### DIFF
--- a/chirrin-chirrion.gemspec
+++ b/chirrin-chirrion.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redis', '~> 3.2.1'
   
   #Runtime dependencies
-  spec.add_runtime_dependency 'json', '~> 1.8.2'
+  spec.add_runtime_dependency 'json', '>= 1'
 end


### PR DESCRIPTION
Today many gems has json as a dependency... this way if you fixed the json version with a higher version the other gems that depends of lower versions, they wont work together with your gem...

As you are using basic functionalities from json gem, this PR change the dependency to allow more compatibility with other applications and gems.