### PR TITLE
Toggle with start date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes of the project you will find here.
 
+## [0.5.2] - 2015-08-21
+### Changed
+ - Use single quotes throughout the classes
+ - Minor fix on methods documentation
+
+
 ## [0.5.1] - 2015-08-21
 ### Changed
  - Add toggle rises an exeption when toggle name is not sent
@@ -11,8 +17,8 @@ All notable changes of the project you will find here.
 
 ## [0.4.0] - 2015-06-19
 ### Changed
- - Redis adaprer: new method #list which returns all registered toggles 
- - ChirrinChirrion: new method #list which returns all registered toggles 
+ - Redis adaprer: new method #list which returns all registered toggles
+ - ChirrinChirrion: new method #list which returns all registered toggles
 
 ## [0.3.0] - 2015-06-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes of the project you will find here.
 ### Changed
  - Use single quotes throughout the classes
  - Minor fix on methods documentation
+ - Add capability to set a time when the trigger will become active
 
 
 ## [0.5.1] - 2015-08-21

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ChirrinChirrion.list
 
 ### Adding a toggle
 ```ruby
-ChirrinChirrion.add_toggle('new_user_register_validation', {active: true, description: 'When this is active, gender, age and phone number are not required'})
+ChirrinChirrion.add_toggle('new_user_register_validation', { active: true, description: 'When this is active, gender, age and phone number are not required' })
 ```
 
 ### Removing a toggle
@@ -65,4 +65,20 @@ end
 chirrion_behavior = { result: 'old static result' }
 
 ChirrinChirrion.chirrin_chirrion('my_toggle', chirrin_behavior, chirrion_behavior)
+```
+
+### Configure a toggle to be activated in a specific time
+
+```ruby
+ChirrinChirrion.add_toggle('my_toggle', { active: false, valid_after: Time.parse('2018-10-10 14:35') })
+
+
+# before the date:
+ChirrinChirrion.chirrin?('my_toggle')
+# => false
+
+# after the date:
+ChirrinChirrion.chirrin?('my_toggle')
+# => true
+
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
-require "bundler/gem_tasks"
-
+require 'bundler/gem_tasks'

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "chirrin-chirrion"
+require 'bundler/setup'
+require 'chirrin-chirrion'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
+# require 'pry'
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/chirrin-chirrion.gemspec
+++ b/chirrin-chirrion.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2.0'
   spec.add_development_dependency 'redis', '~> 3.2.1'
-  
+
   #Runtime dependencies
   spec.add_runtime_dependency 'json', '>= 1'
 end

--- a/lib/chirrin-chirrion.rb
+++ b/lib/chirrin-chirrion.rb
@@ -84,8 +84,8 @@ module ChirrinChirrion
   #
   # ChirrinChirrion.chirrin('mult_for_2')
   # ten_numbers            = (1..10).to_a
-  # actiction_for_chirrin  = lambda { ten_numbers.map{|number| number * 2 } }
-  # actiction_for_chirrion = lambda { ten_numbers.map{|number| number * 4 } }
+  # action_for_chirrin  = lambda { ten_numbers.map{|number| number * 2 } }
+  # action_for_chirrion = lambda { ten_numbers.map{|number| number * 4 } }
   # ChirrinChirrion.chirrin_chirrion('mult_for_2', action_for_chirrin, action_for_chirrion) #=> [4, 8, 12, 16, 20, 24, 28, 32, 36, 40]
   # ChirrinChirrion.chirrin('mult_for_2')
   # ChirrinChirrion.chirrin_chirrion('mult_for_2', action_for_chirrin, action_for_chirrion) #=> [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]

--- a/lib/chirrin-chirrion/database_adapters/redis_adapter.rb
+++ b/lib/chirrin-chirrion/database_adapters/redis_adapter.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require 'time'
 
 module ChirrinChirrion
   module DatabaseAdapters
@@ -67,6 +68,8 @@ module ChirrinChirrion
         toggle_info = get_toggle_info(toggle_name)
         return false unless toggle_info
 
+        activate_scheduled_toggle(toggle_name, toggle_info['valid_after'])
+
         toggle_info['active'].eql?(true)
       end
 
@@ -91,6 +94,12 @@ module ChirrinChirrion
         return nil unless toggle_info
 
         JSON.parse(toggle_info)
+      end
+
+      def activate_scheduled_toggle(toggle_name, valid_after)
+        return unless valid_after
+
+        activate!(toggle_name) if Time.parse(valid_after) <= Time.now
       end
     end
   end

--- a/lib/chirrin-chirrion/version.rb
+++ b/lib/chirrin-chirrion/version.rb
@@ -1,3 +1,3 @@
 module ChirrinChirrion
-  VERSION = "0.5.1"
+  VERSION = '0.5.2'
 end

--- a/spec/chirrin-chirrion_spec.rb
+++ b/spec/chirrin-chirrion_spec.rb
@@ -4,7 +4,7 @@ describe ChirrinChirrion do
   let(:database_adapter) { double }
   before { ChirrinChirrion.config(database_adapter: database_adapter) }
 
-  describe ".add_toggle" do
+  describe '.add_toggle' do
     context 'when toggle name is sent' do
       let(:toggle_name) { 'my_toggle' }
 
@@ -12,7 +12,7 @@ describe ChirrinChirrion do
         before { allow(database_adapter).to receive(:add_toggle) { true } }
 
         it 'returns true' do
-          expect(subject.add_toggle(toggle_name, {active: true, description: 'This feature do that'})).to eq(true)
+          expect(subject.add_toggle(toggle_name, { active: true, description: 'This feature do that' })).to eq(true)
         end
       end
 
@@ -20,7 +20,7 @@ describe ChirrinChirrion do
         before { allow(database_adapter).to receive(:add_toggle) { false } }
 
         it 'returns false' do
-          expect(subject.add_toggle(toggle_name, {active: true, description: 'This feature do that'})).to eq(false)
+          expect(subject.add_toggle(toggle_name, { active: true, description: 'This feature do that' })).to eq(false)
         end
       end
     end
@@ -34,7 +34,7 @@ describe ChirrinChirrion do
     end
   end
 
-  describe ".remove_toggle" do
+  describe '.remove_toggle' do
     let(:toggle_name) { 'my_toggle' }
 
     context 'when the database adapter returns ok' do
@@ -54,7 +54,7 @@ describe ChirrinChirrion do
     end
   end
 
-  describe ".chirrin!" do
+  describe '.chirrin!' do
     let(:toggle_name) { 'my_toggle' }
 
     context 'when the database adapter returns ok' do
@@ -74,7 +74,7 @@ describe ChirrinChirrion do
     end
   end
 
-  describe ".chirrion!" do
+  describe '.chirrion!' do
     let(:toggle_name) { 'my_toggle' }
 
     context 'when the database adapter returns ok' do
@@ -94,7 +94,7 @@ describe ChirrinChirrion do
     end
   end
 
-  describe ".chirrin?" do
+  describe '.chirrin?' do
     let(:toggle_name) { 'my_toggle' }
 
     context 'when the database adapter returns ok' do
@@ -114,7 +114,7 @@ describe ChirrinChirrion do
     end
   end
 
-  describe ".chirrion?" do
+  describe '.chirrion?' do
     let(:toggle_name) { 'my_toggle' }
 
     context 'when the database adapter returns ok' do
@@ -134,7 +134,7 @@ describe ChirrinChirrion do
     end
   end
 
-  describe ".chirrin_chirrion" do
+  describe '.chirrin_chirrion' do
     let(:toggle_name) { 'my_toggle' }
 
     context 'when the toggle is turned on' do
@@ -194,7 +194,7 @@ describe ChirrinChirrion do
     end
 
     context 'when the adapter returns a list' do
-      let(:database_adapter_list) {[OpenStruct.new, OpenStruct.new]}
+      let(:database_adapter_list) { [OpenStruct.new, OpenStruct.new] }
 
       it 'returns the list' do
         expect(subject.list.size).to eq(2)

--- a/spec/database_adapters/redis_adapter_spec.rb
+++ b/spec/database_adapters/redis_adapter_spec.rb
@@ -123,7 +123,7 @@ describe ChirrinChirrion::DatabaseAdapters::RedisAdapter do
         let(:toggle_info) { { active: false, valid_after: Time.now + 1 } }
 
         it 'returns false' do
-          expect(subject.active?(toggle_name)).to eq(false)
+          expect(subject.active?(toggle_name)).to be_falsy
         end
       end
 
@@ -133,8 +133,8 @@ describe ChirrinChirrion::DatabaseAdapters::RedisAdapter do
         before { allow(Time).to receive(:now).and_return(date) }
 
         it 'activates the toggle' do
-          expect(redis_database).to receive(:hset).with('chirrin-chirrion-toggles', toggle_name, { active: true, valid_after: date }.to_json) { 1 }
-          subject.active?(toggle_name)
+          expect(redis_database).to receive(:hset).with('chirrin-chirrion-toggles', toggle_name, { active: true }.to_json) { 1 }
+          expect(subject.active?(toggle_name)).to be_truthy
         end
       end
 
@@ -142,8 +142,8 @@ describe ChirrinChirrion::DatabaseAdapters::RedisAdapter do
         let(:toggle_info) { { active: false, valid_after: Time.now - 1 } }
 
         it 'activates the toggle' do
-          expect(redis_database).to receive(:hset).with('chirrin-chirrion-toggles', toggle_name, { active: true, valid_after: toggle_info[:valid_after] }.to_json) { 1 }
-          subject.active?(toggle_name)
+          expect(redis_database).to receive(:hset).with('chirrin-chirrion-toggles', toggle_name, { active: true }.to_json) { 1 }
+          expect(subject.active?(toggle_name)).to be_truthy
         end
       end
     end


### PR DESCRIPTION
This PR adds the possibility to include toggles that start to work in a specific date. I didn't create a new method. Instead, I used the methods already stablished and I used the toggle_info to include a `valid_after` time information.

Not that I used Time and not Date, to give more control of the toggle to those who want to use it.

Once a toggle is checked with `active?`, it checks the valid_after attribute and, if the time has come, it activates the toggle.

Steps:
* [x] Improve the code style
* [x] Create the mechanism to start the toggle
* [x] Prevent the toggle to be activated again. If the toggle was activated because of the date and is manually deactivated, it should remain disabled.
* [x] Add changelog and information on README